### PR TITLE
docs: using consistent parameter naming to reduce confusion

### DIFF
--- a/docs/pages/examples/hotp.md
+++ b/docs/pages/examples/hotp.md
@@ -13,7 +13,7 @@ const digits = 6;
 let counter = 10n;
 
 const otp = generateHOTP(key, counter, digits);
-const validOTP = verifyOTP(otp, secret, counter, digits);
+const validOTP = verifyOTP(otp, key, counter, digits);
 ```
 
 Use [`createHOTPKeyURI()`](/reference/main/createHOTPKeyURI) to create a key URI, which are then usually encoded into a QR code.

--- a/docs/pages/examples/totp.md
+++ b/docs/pages/examples/totp.md
@@ -13,7 +13,7 @@ const digits = 6;
 const intervalInSeconds = 30;
 
 const otp = generateTOTP(key, intervalInSeconds, digits);
-const validOTP = verifyTOTP(otp, secret, intervalInSeconds, digits);
+const validOTP = verifyTOTP(otp, key, intervalInSeconds, digits);
 ```
 
 Use [`createTOTPKeyURI()`](/reference/main/createTOTPKeyURI) to create a key URI, which are then usually encoded into a QR code.


### PR DESCRIPTION
Update docs to use consistent parameter naming `key`, enhancing clarity and reducing confusion.