### PR TITLE
Fix documentation examples: Correct parameter order and method names

### DIFF
--- a/docs/pages/examples/hotp.md
+++ b/docs/pages/examples/hotp.md
@@ -13,7 +13,7 @@ const digits = 6;
 let counter = 10n;
 
 const otp = generateHOTP(key, counter, digits);
-const validOTP = verifyOTP(key, counter, digits, otp);
+const validOTP = verifyHOTP(key, counter, digits, otp);
 ```
 
 Use [`createHOTPKeyURI()`](/reference/main/createHOTPKeyURI) to create a key URI, which are then usually encoded into a QR code.

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -16,7 +16,7 @@ Supports HMAC-based one-time passwords (HOTP) and time-based one-time passwords 
 import { generateTOTP, verifyTOTP } from "@oslojs/otp";
 
 const totp = generateTOTP(key, 30, 6);
-const valid = verifyTOTP(totp, key, 30, 6);
+const valid = verifyTOTP(key, 30, 6, totp);
 ```
 
 ## Installation


### PR DESCRIPTION
- Corrects the parameter sequence in the `verifyTOTP` example.
- Replaces `verifyOTP` with `verifyHOTP` in the HOTP example.